### PR TITLE
Adressed pytest warnings - Issue #599

### DIFF
--- a/neuralprophet/benchmark.py
+++ b/neuralprophet/benchmark.py
@@ -537,8 +537,12 @@ class CrossValidationExperiment(Experiment):
         if self.save_dir is not None:
             results_cv_test_df = pd.DataFrame()
             results_cv_train_df = pd.DataFrame()
-            results_cv_test_df = results_cv_test_df.append(self.results_cv_test, ignore_index=True)
-            results_cv_train_df = results_cv_train_df.append(self.results_cv_train, ignore_index=True)
+            results_cv_test_df = pd.concat(
+                [results_cv_test_df, pd.DataFrame([self.results_cv_test])], axis=0, join="outer", ignore_index=True
+            )
+            results_cv_train_df = pd.concat(
+                [results_cv_train_df, pd.DataFrame([self.results_cv_train])], axis=0, join="outer", ignore_index=True
+            )
             self.write_results_to_csv(results_cv_test_df, prefix="summary_test")
             self.write_results_to_csv(results_cv_train_df, prefix="summary_train")
 
@@ -592,8 +596,12 @@ class Benchmark(ABC):
             results = [results]
         for res in results:
             res_train, res_test = res
-            self.df_metrics_train = self.df_metrics_train.append(res_train, ignore_index=True)
-            self.df_metrics_test = self.df_metrics_test.append(res_test, ignore_index=True)
+            self.df_metrics_train = pd.concat(
+                [self.df_metrics_train, pd.DataFrame([res_train])], axis=0, join="outer", ignore_index=True
+            )
+            self.df_metrics_test = pd.concat(
+                [self.df_metrics_test, pd.DataFrame([res_test])], axis=0, join="outer", ignore_index=True
+            )
 
     def _log_error(self, error):
         log.error(repr(error))
@@ -660,7 +668,7 @@ class CVBenchmark(Benchmark, ABC):
         df_metrics_summary_train["split"] = "train"
         df_metrics_summary_test = self._summarize_cv_metrics(df_metrics_test)
         df_metrics_summary_test["split"] = "test"
-        df_metrics_summary = df_metrics_summary_train.append(df_metrics_summary_test)
+        df_metrics_summary = pd.concat([df_metrics_summary_train, df_metrics_summary_test], axis=0, join="outer")
         if self.save_dir is not None:
             self.write_summary_to_csv(df_metrics_summary, save_dir=self.save_dir)
         return df_metrics_summary, df_metrics_train, df_metrics_test

--- a/neuralprophet/benchmark.py
+++ b/neuralprophet/benchmark.py
@@ -538,10 +538,10 @@ class CrossValidationExperiment(Experiment):
             results_cv_test_df = pd.DataFrame()
             results_cv_train_df = pd.DataFrame()
             results_cv_test_df = pd.concat(
-                [results_cv_test_df, pd.DataFrame([self.results_cv_test])], axis=0, join="outer", ignore_index=True
+                [results_cv_test_df, pd.DataFrame([self.results_cv_test])], ignore_index=True
             )
             results_cv_train_df = pd.concat(
-                [results_cv_train_df, pd.DataFrame([self.results_cv_train])], axis=0, join="outer", ignore_index=True
+                [results_cv_train_df, pd.DataFrame([self.results_cv_train])], ignore_index=True
             )
             self.write_results_to_csv(results_cv_test_df, prefix="summary_test")
             self.write_results_to_csv(results_cv_train_df, prefix="summary_train")
@@ -596,12 +596,8 @@ class Benchmark(ABC):
             results = [results]
         for res in results:
             res_train, res_test = res
-            self.df_metrics_train = pd.concat(
-                [self.df_metrics_train, pd.DataFrame([res_train])], axis=0, join="outer", ignore_index=True
-            )
-            self.df_metrics_test = pd.concat(
-                [self.df_metrics_test, pd.DataFrame([res_test])], axis=0, join="outer", ignore_index=True
-            )
+            self.df_metrics_train = pd.concat([self.df_metrics_train, pd.DataFrame([res_train])], ignore_index=True)
+            self.df_metrics_test = pd.concat([self.df_metrics_test, pd.DataFrame([res_test])], ignore_index=True)
 
     def _log_error(self, error):
         log.error(repr(error))
@@ -668,7 +664,7 @@ class CVBenchmark(Benchmark, ABC):
         df_metrics_summary_train["split"] = "train"
         df_metrics_summary_test = self._summarize_cv_metrics(df_metrics_test)
         df_metrics_summary_test["split"] = "test"
-        df_metrics_summary = pd.concat([df_metrics_summary_train, df_metrics_summary_test], axis=0, join="outer")
+        df_metrics_summary = pd.concat([df_metrics_summary_train, df_metrics_summary_test])
         if self.save_dir is not None:
             self.write_summary_to_csv(df_metrics_summary, save_dir=self.save_dir)
         return df_metrics_summary, df_metrics_train, df_metrics_test

--- a/neuralprophet/df_utils.py
+++ b/neuralprophet/df_utils.py
@@ -349,7 +349,7 @@ def get_normalization_params(array, norm_type):
     non_nan_array = array[~np.isnan(array)]
     if norm_type == "soft":
         lowest = np.min(non_nan_array)
-        q95 = np.quantile(non_nan_array, 0.95, interpolation="higher")
+        q95 = np.quantile(non_nan_array, 0.95, method="higher")
         width = q95 - lowest
         if math.isclose(width, 0):
             width = np.max(non_nan_array) - lowest
@@ -357,7 +357,7 @@ def get_normalization_params(array, norm_type):
         scale = width
     elif norm_type == "soft1":
         lowest = np.min(non_nan_array)
-        q90 = np.quantile(non_nan_array, 0.9, interpolation="higher")
+        q90 = np.quantile(non_nan_array, 0.9, method="higher")
         width = q90 - lowest
         if math.isclose(width, 0):
             width = (np.max(non_nan_array) - lowest) / 1.25

--- a/neuralprophet/forecaster.py
+++ b/neuralprophet/forecaster.py
@@ -1646,7 +1646,7 @@ class NeuralProphet:
                 #    )
                 # END FIX
         if df_end_to_append is not None:
-            df = df.append(df_end_to_append)
+            df = pd.concat([df, df_end_to_append], axis=0, join="outer")
         return df
 
     def _handle_missing_data(self, df, freq, predicting=False):
@@ -2308,7 +2308,7 @@ class NeuralProphet:
                 regressors_df=regressors_df,
             )
             if len(df) > 0:
-                df = df.append(future_df)
+                df = pd.concat([df, future_df], axis=0, join="outer")
             else:
                 df = future_df
         df.reset_index(drop=True, inplace=True)
@@ -2345,7 +2345,7 @@ class NeuralProphet:
                     periods=periods_add[df_name],
                     freq=self.data_freq,
                 )
-                df = df.append(future_df)
+                df = pd.concat([df, future_df], axis=0, join="outer")
                 df.reset_index(drop=True, inplace=True)
             df_dict[df_name] = df
         return df_dict, periods_add

--- a/neuralprophet/forecaster.py
+++ b/neuralprophet/forecaster.py
@@ -2556,5 +2556,5 @@ class NeuralProphet:
                 forecast_0 = components[comp][0, :]
                 forecast_rest = components[comp][1:, self.n_forecasts - 1]
                 yhat = np.concatenate(([None] * self.max_lags, forecast_0, forecast_rest))
-                df_forecast[comp] = yhat
+                df_forecast = pd.concat([df_forecast, pd.Series(yhat, name=comp)], axis=1, ignore_index=False)
         return df_forecast

--- a/neuralprophet/forecaster.py
+++ b/neuralprophet/forecaster.py
@@ -1646,7 +1646,7 @@ class NeuralProphet:
                 #    )
                 # END FIX
         if df_end_to_append is not None:
-            df = pd.concat([df, df_end_to_append], axis=0, join="outer")
+            df = pd.concat([df, df_end_to_append])
         return df
 
     def _handle_missing_data(self, df, freq, predicting=False):
@@ -2308,7 +2308,7 @@ class NeuralProphet:
                 regressors_df=regressors_df,
             )
             if len(df) > 0:
-                df = pd.concat([df, future_df], axis=0, join="outer")
+                df = pd.concat([df, future_df])
             else:
                 df = future_df
         df.reset_index(drop=True, inplace=True)
@@ -2345,7 +2345,7 @@ class NeuralProphet:
                     periods=periods_add[df_name],
                     freq=self.data_freq,
                 )
-                df = pd.concat([df, future_df], axis=0, join="outer")
+                df = pd.concat([df, future_df])
                 df.reset_index(drop=True, inplace=True)
             df_dict[df_name] = df
         return df_dict, periods_add

--- a/neuralprophet/utils.py
+++ b/neuralprophet/utils.py
@@ -237,15 +237,11 @@ def events_config_to_model_dims(events_config, country_holidays_config):
                             additive_events_dims,
                             pd.DataFrame([{"event": event, "event_delim": event_delim}]),
                         ],
-                        axis=0,
-                        join="outer",
                         ignore_index=True,
                     )
                 else:
                     multiplicative_events_dims = pd.concat(
                         [multiplicative_events_dims, pd.DataFrame([{"event": event, "event_delim": event_delim}])],
-                        axis=0,
-                        join="outer",
                         ignore_index=True,
                     )
 
@@ -262,8 +258,6 @@ def events_config_to_model_dims(events_config, country_holidays_config):
                             additive_events_dims,
                             pd.DataFrame([{"event": country_holiday, "event_delim": holiday_delim}]),
                         ],
-                        axis=0,
-                        join="outer",
                         ignore_index=True,
                     )
                 else:
@@ -272,8 +266,6 @@ def events_config_to_model_dims(events_config, country_holidays_config):
                             multiplicative_events_dims,
                             pd.DataFrame([{"event": country_holiday, "event_delim": holiday_delim}]),
                         ],
-                        axis=0,
-                        join="outer",
                         ignore_index=True,
                     )
 

--- a/neuralprophet/utils.py
+++ b/neuralprophet/utils.py
@@ -232,12 +232,21 @@ def events_config_to_model_dims(events_config, country_holidays_config):
             for offset in range(configs.lower_window, configs.upper_window + 1):
                 event_delim = create_event_names_for_offsets(event, offset)
                 if mode == "additive":
-                    additive_events_dims = additive_events_dims.append(
-                        {"event": event, "event_delim": event_delim}, ignore_index=True
+                    additive_events_dims = pd.concat(
+                        [
+                            additive_events_dims,
+                            pd.DataFrame([{"event": event, "event_delim": event_delim}]),
+                        ],
+                        axis=0,
+                        join="outer",
+                        ignore_index=True,
                     )
                 else:
-                    multiplicative_events_dims = multiplicative_events_dims.append(
-                        {"event": event, "event_delim": event_delim}, ignore_index=True
+                    multiplicative_events_dims = pd.concat(
+                        [multiplicative_events_dims, pd.DataFrame([{"event": event, "event_delim": event_delim}])],
+                        axis=0,
+                        join="outer",
+                        ignore_index=True,
                     )
 
     if country_holidays_config is not None:
@@ -248,12 +257,24 @@ def events_config_to_model_dims(events_config, country_holidays_config):
             for offset in range(lower_window, upper_window + 1):
                 holiday_delim = create_event_names_for_offsets(country_holiday, offset)
                 if mode == "additive":
-                    additive_events_dims = additive_events_dims.append(
-                        {"event": country_holiday, "event_delim": holiday_delim}, ignore_index=True
+                    additive_events_dims = pd.concat(
+                        [
+                            additive_events_dims,
+                            pd.DataFrame([{"event": country_holiday, "event_delim": holiday_delim}]),
+                        ],
+                        axis=0,
+                        join="outer",
+                        ignore_index=True,
                     )
                 else:
-                    multiplicative_events_dims = multiplicative_events_dims.append(
-                        {"event": country_holiday, "event_delim": holiday_delim}, ignore_index=True
+                    multiplicative_events_dims = pd.concat(
+                        [
+                            multiplicative_events_dims,
+                            pd.DataFrame([{"event": country_holiday, "event_delim": holiday_delim}]),
+                        ],
+                        axis=0,
+                        join="outer",
+                        ignore_index=True,
                     )
 
     # sort based on event_delim
@@ -266,7 +287,7 @@ def events_config_to_model_dims(events_config, country_holidays_config):
     if not multiplicative_events_dims.empty:
         multiplicative_events_dims = multiplicative_events_dims.sort_values(by="event_delim").reset_index(drop=True)
         multiplicative_events_dims["mode"] = "multiplicative"
-        event_dims = event_dims.append(multiplicative_events_dims)
+        event_dims = pd.concat([event_dims, multiplicative_events_dims], axis=0, join="outer")
 
     event_dims_dic = OrderedDict({})
     # convert to dict format
@@ -345,7 +366,7 @@ def regressors_config_to_model_dims(regressors_config):
             multiplicative_regressors = sorted(multiplicative_regressors)
             multiplicative_regressors_dims = pd.DataFrame(data=multiplicative_regressors, columns=["regressors"])
             multiplicative_regressors_dims["mode"] = "multiplicative"
-            regressors_dims = regressors_dims.append(multiplicative_regressors_dims)
+            regressors_dims = pd.concat([regressors_dims, multiplicative_regressors_dims], axis=0, join="outer")
 
         regressors_dims_dic = OrderedDict({})
         # convert to dict format

--- a/neuralprophet/utils.py
+++ b/neuralprophet/utils.py
@@ -287,7 +287,7 @@ def events_config_to_model_dims(events_config, country_holidays_config):
     if not multiplicative_events_dims.empty:
         multiplicative_events_dims = multiplicative_events_dims.sort_values(by="event_delim").reset_index(drop=True)
         multiplicative_events_dims["mode"] = "multiplicative"
-        event_dims = pd.concat([event_dims, multiplicative_events_dims], axis=0, join="outer")
+        event_dims = pd.concat([event_dims, multiplicative_events_dims])
 
     event_dims_dic = OrderedDict({})
     # convert to dict format
@@ -366,7 +366,7 @@ def regressors_config_to_model_dims(regressors_config):
             multiplicative_regressors = sorted(multiplicative_regressors)
             multiplicative_regressors_dims = pd.DataFrame(data=multiplicative_regressors, columns=["regressors"])
             multiplicative_regressors_dims["mode"] = "multiplicative"
-            regressors_dims = pd.concat([regressors_dims, multiplicative_regressors_dims], axis=0, join="outer")
+            regressors_dims = pd.concat([regressors_dims, multiplicative_regressors_dims])
 
         regressors_dims_dic = OrderedDict({})
         # convert to dict format

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1302,7 +1302,7 @@ def test_drop_missing_values_after_imputation():
     )
     df = pd.read_csv(PEYTON_FILE, nrows=NROWS)
     # introduce large window of NaN values, from which samples will be dropped after imputation
-    df["y"][100:131] = np.nan
+    df.loc[100:131, "y"] = np.nan
     metrics = m.fit(df, freq="D", validation_df=None)
     future = m.make_future_dataframe(df, periods=60, n_historic_predictions=60)
     forecast = m.predict(df=future)


### PR DESCRIPTION
Requested by #599.

**Status quo**
When running `pytest -v` on main, the pytest summary currently yields 626 warnings.

**Changes**
This pr resolves all warnings by refactoring the code according to the pandas docs:
- 615 Warnings: Replaced frame.append with pd.concat, according to [Pandas Deprecation Note 1.4.0](https://pandas.pydata.org/pandas-docs/dev/whatsnew/v1.4.0.html#deprecated-dataframe-append-and-series-append)
- 8 Warnings: Replaced dataframe slicing (eg. df["abc"] = ...) with pd.concat, according to [Appending rows to a DataFrame](https://pandas.pydata.org/pandas-docs/stable/user_guide/merging.html#appending-rows-to-a-dataframe)
- 1 Warning: Replaced dataframe slicing for value assignment with frame.loc, according to [Setting values in a DataFrame](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.loc.html)
- 2 Warnings: Replace the `interpolation=` arg of np.quantile with `method=`, according to [Numpy Deprecarion Note 1.22.0](https://numpy.org/devdocs/release/1.22.0-notes.html#add-new-methods-for-quantile-and-percentile)